### PR TITLE
3998: Wordpress Template Fixes

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,19 +3,9 @@ class ApplicationController < ActionController::Base
   # For APIs, you may want to use :null_session instead.
   protect_from_forgery with: :exception
 
-  def get_division_from_url
-    @get_division_from_url ||= Rails.configuration.x.wordpress_template[:division_urls].select { |key, val|
-      request.url.match key
-    }.values.first || default_division
-  end
-  helper_method :get_division_from_url
+  private
 
-  def default_division
-    :us
-  end
-
-  def update_template
-    WordpressTemplate.update(get_division_from_url)
-    redirect_to root_path
+  def set_locale
+    I18n.locale = params[:locale] || I18n.default_locale
   end
 end

--- a/app/controllers/concerns/wordpress_embeddable.rb
+++ b/app/controllers/concerns/wordpress_embeddable.rb
@@ -1,0 +1,37 @@
+module WordpressEmbeddable
+  extend ActiveSupport::Concern
+
+  included do
+    before_action :update_template
+    helper_method :get_division_from_url
+  end
+
+  # def get_division_from_url
+  #   # @get_division_from_url ||= Rails.configuration.x.wordpress_template[:division_urls].select { |key, val|
+  #   #   request.url.match key
+  #   # }.values.first || default_division
+  # end
+
+  def default_division
+    :us
+  end
+
+  def get_division_from_url
+    division_urls = Rails.configuration.x.wordpress_template[:division_urls]
+    matching = division_urls.select { |expression, _| request.url.match expression }
+    division = matching.values.first
+    division || default_division
+  end
+
+  private
+
+  def update_template
+    template_path = "layouts/embedded/wordpress-#{get_division_from_url}"
+    return if template_exists?(template_path)
+    WordpressTemplate.update(
+      division: get_division_from_url,
+      base_uri: [request.protocol, request.host_with_port].join
+    )
+  end
+
+end

--- a/app/controllers/loans_controller.rb
+++ b/app/controllers/loans_controller.rb
@@ -1,4 +1,5 @@
 class LoansController < ApplicationController
+  include WordpressEmbeddable
   # GET /loans
   # GET /loans.json
   def index
@@ -13,9 +14,8 @@ class LoansController < ApplicationController
     session[:loans_path] = request.fullpath
 
     respond_to do |format|
-      # Call update_template to pull layout from wordpress if it hasn't been loaded
-      format.html { redirect_to update_template_path if !template_exists?("layouts/wordpress-#{get_division_from_url}") }
-      format.json { render :json => @loans }
+      format.html
+      format.json { render json: @loans }
     end
   end
 
@@ -43,5 +43,4 @@ class LoansController < ApplicationController
       format.html
     end
   end
-
 end

--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -1,0 +1,7 @@
+class StaticPagesController < ApplicationController
+  include WordpressEmbeddable
+
+  def test
+    render inline: "<% provide :title, 'Test' %><h1>Test Successful</h1>", layout: 'application'
+  end
+end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -38,10 +38,10 @@ Rails.application.configure do
   # For wordpress template
   config.x.wordpress_template = {
     division_urls: { # get division from request url
-      'http://localhost:3000' => :us,
+      '/' => :us,
     },
-    template_urls: { # url of blank wordpress page for rails to retrieve
-      us: 'http://localhost:8888/us-dev/rails',
+    template_paths: { # url of blank wordpress page for rails to retrieve
+      us: '/wordpress/rails_template',
     },
   }
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -82,9 +82,9 @@ Rails.application.configure do
       %r{http://.*\.?theworkingworld\.org} => :us,
       'http://labase.org/inversion' => :argentina,
     },
-    template_urls: { # url of blank wordpress page for rails to retrieve
-      us: 'http://www.theworkingworld.org/us/rails',
-      argentina: 'http://labase.org/rails',
+    template_paths: { # url of blank wordpress page for rails to retrieve
+      us: '/us/rails',
+      argentina: '/rails',
     },
   }
 

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -45,8 +45,8 @@ Rails.application.configure do
     division_urls: { # get division from request url
       'http://localhost:3000' => :us,
     },
-    template_urls: { # url of blank wordpress page for rails to retrieve
-      us: 'http://localhost:8888/us-dev/rails',
+    template_paths: { # url of blank wordpress page for rails to retrieve
+      us: '/wordpress/rails_template',
     },
   }
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -31,5 +31,7 @@ Rails.application.routes.draw do
     get 'loans/:id/gallery', to: 'loans#gallery', as: :gallery
   end
 
+  get '/test' => 'static_pages#test'
+
   root to: 'admin/dashboard#index'
 end

--- a/lib/wordpress_template.rb
+++ b/lib/wordpress_template.rb
@@ -1,14 +1,26 @@
 module WordpressTemplate
-  def self.update(division)
-    template_url = Rails.configuration.wordpress_template[:template_urls][division]
-    file = File.join(Rails.root, 'app', 'views', 'layouts', "wordpress-#{division}.html.erb")
+  def self.update(division:, base_uri:)
+    if Rails.env.development? || Rails.env.test?
+      html = File.read(Rails.root.join('spec', 'fixtures', 'wordpress-rails.html'))
+    else
+      html = self.fetch_template(division: division, base_uri: base_uri)
+    end
+    self.process_template(division: division, html: html)
+  end
+
+  def self.fetch_template(division:, base_uri:)
+    require 'open-uri'
+    template_path = Rails.configuration.x.wordpress_template[:template_paths][division]
+    template_url = [base_uri, template_path].join
+    html = URI.parse(template_url).read
+  end
+
+  def self.process_template(division:, html:)
+    file = File.join(Rails.root, 'app', 'views', 'layouts', 'embedded', "wordpress-#{division}.html.erb")
     additional_substitutions = [
       [/<div class="post-content">(.*?)<p>(.*?)<\/p>(.*?)<\/div>/m, '\1\2\3'],
       ['<div class="article-single">', '<div>'],
     ]
-
-    require 'open-uri'
-    html = URI.parse(template_url).read
     html.gsub!(
       /(<!--\s*)?\[rails_(?<section>[\w\-]+?)\](.*\[\/rails_\k<section>\])?(\s*-->)?/m,
       '<%= yield :\k<section> %>'

--- a/spec/fixtures/wordpress-rails.html
+++ b/spec/fixtures/wordpress-rails.html
@@ -1,0 +1,120 @@
+
+<!DOCTYPE html>
+<html lang="en-US" class="no-js">
+<head>
+	<meta charset="UTF-8">
+	<meta name="viewport" content="width=device-width, initial-scale=1">
+	<link rel="profile" href="http://gmpg.org/xfn/11">
+		<script>(function(html){html.className = html.className.replace(/\bno-js\b/,'js')})(document.documentElement);</script>
+<title>[rails_template] &#8211; Madeline System WP</title>
+<meta name='robots' content='noindex,follow' />
+<link rel="alternate" type="application/rss+xml" title="Madeline System WP &raquo; Feed" href="http://localhost:8888/feed/" />
+<link rel="alternate" type="application/rss+xml" title="Madeline System WP &raquo; Comments Feed" href="http://localhost:8888/comments/feed/" />
+		<script type="text/javascript">
+			window._wpemojiSettings = {"baseUrl":"http:\/\/s.w.org\/images\/core\/emoji\/72x72\/","ext":".png","source":{"concatemoji":"http:\/\/localhost:8888\/wp-includes\/js\/wp-emoji-release.min.js?ver=4.4.1"}};
+			!function(a,b,c){function d(a){var c,d=b.createElement("canvas"),e=d.getContext&&d.getContext("2d");return e&&e.fillText?(e.textBaseline="top",e.font="600 32px Arial","flag"===a?(e.fillText(String.fromCharCode(55356,56806,55356,56826),0,0),d.toDataURL().length>3e3):"diversity"===a?(e.fillText(String.fromCharCode(55356,57221),0,0),c=e.getImageData(16,16,1,1).data.toString(),e.fillText(String.fromCharCode(55356,57221,55356,57343),0,0),c!==e.getImageData(16,16,1,1).data.toString()):("simple"===a?e.fillText(String.fromCharCode(55357,56835),0,0):e.fillText(String.fromCharCode(55356,57135),0,0),0!==e.getImageData(16,16,1,1).data[0])):!1}function e(a){var c=b.createElement("script");c.src=a,c.type="text/javascript",b.getElementsByTagName("head")[0].appendChild(c)}var f,g;c.supports={simple:d("simple"),flag:d("flag"),unicode8:d("unicode8"),diversity:d("diversity")},c.DOMReady=!1,c.readyCallback=function(){c.DOMReady=!0},c.supports.simple&&c.supports.flag&&c.supports.unicode8&&c.supports.diversity||(g=function(){c.readyCallback()},b.addEventListener?(b.addEventListener("DOMContentLoaded",g,!1),a.addEventListener("load",g,!1)):(a.attachEvent("onload",g),b.attachEvent("onreadystatechange",function(){"complete"===b.readyState&&c.readyCallback()})),f=c.source||{},f.concatemoji?e(f.concatemoji):f.wpemoji&&f.twemoji&&(e(f.twemoji),e(f.wpemoji)))}(window,document,window._wpemojiSettings);
+		</script>
+		<style type="text/css">
+img.wp-smiley,
+img.emoji {
+	display: inline !important;
+	border: none !important;
+	box-shadow: none !important;
+	height: 1em !important;
+	width: 1em !important;
+	margin: 0 .07em !important;
+	vertical-align: -0.1em !important;
+	background: none !important;
+	padding: 0 !important;
+}
+</style>
+<link rel='stylesheet' id='twentysixteen-fonts-css'  href='https://fonts.googleapis.com/css?family=Merriweather%3A400%2C700%2C900%2C400italic%2C700italic%2C900italic%7CMontserrat%3A400%2C700%7CInconsolata%3A400&#038;subset=latin%2Clatin-ext' type='text/css' media='all' />
+<link rel='stylesheet' id='genericons-css'  href='http://localhost:8888/wp-content/themes/twentysixteen/genericons/genericons.css?ver=3.4.1' type='text/css' media='all' />
+<link rel='stylesheet' id='twentysixteen-style-css'  href='http://localhost:8888/wp-content/themes/twentysixteen/style.css?ver=4.4.1' type='text/css' media='all' />
+<!--[if lt IE 10]>
+<link rel='stylesheet' id='twentysixteen-ie-css'  href='http://localhost:8888/wp-content/themes/twentysixteen/css/ie.css?ver=20150930' type='text/css' media='all' />
+<![endif]-->
+<!--[if lt IE 9]>
+<link rel='stylesheet' id='twentysixteen-ie8-css'  href='http://localhost:8888/wp-content/themes/twentysixteen/css/ie8.css?ver=20151230' type='text/css' media='all' />
+<![endif]-->
+<!--[if lt IE 8]>
+<link rel='stylesheet' id='twentysixteen-ie7-css'  href='http://localhost:8888/wp-content/themes/twentysixteen/css/ie7.css?ver=20150930' type='text/css' media='all' />
+<![endif]-->
+<!--[if lt IE 9]>
+<script type='text/javascript' src='http://localhost:8888/wp-content/themes/twentysixteen/js/html5.js?ver=3.7.3'></script>
+<![endif]-->
+<script type='text/javascript' src='http://localhost:8888/wp-includes/js/jquery/jquery.js?ver=1.11.3'></script>
+<script type='text/javascript' src='http://localhost:8888/wp-includes/js/jquery/jquery-migrate.min.js?ver=1.2.1'></script>
+<link rel='https://api.w.org/' href='http://localhost:8888/wp-json/' />
+<link rel="EditURI" type="application/rsd+xml" title="RSD" href="http://localhost:8888/xmlrpc.php?rsd" />
+<link rel="wlwmanifest" type="application/wlwmanifest+xml" href="http://localhost:8888/wp-includes/wlwmanifest.xml" />
+<meta name="generator" content="WordPress 4.4.1" />
+<link rel="canonical" href="http://localhost:8888/rails/" />
+<link rel='shortlink' href='http://localhost:8888/?p=5' />
+<link rel="alternate" type="application/json+oembed" href="http://localhost:8888/wp-json/oembed/1.0/embed?url=http%3A%2F%2Flocalhost%3A8888%2Frails%2F" />
+<link rel="alternate" type="text/xml+oembed" href="http://localhost:8888/wp-json/oembed/1.0/embed?url=http%3A%2F%2Flocalhost%3A8888%2Frails%2F&#038;format=xml" />
+<!--[rails_head]--></head>
+
+<body class="page page-id-5 page-template-default no-sidebar">
+<div id="page" class="site">
+	<div class="site-inner">
+		<a class="skip-link screen-reader-text" href="#content">Skip to content</a>
+
+		<header id="masthead" class="site-header" role="banner">
+			<div class="site-header-main">
+				<div class="site-branding">
+											<p class="site-title"><a href="http://localhost:8888/" rel="home">Madeline System WP</a></p>
+											<p class="site-description">Just a Wordpress Test Site</p>
+									</div><!-- .site-branding -->
+
+							</div><!-- .site-header-main -->
+
+					</header><!-- .site-header -->
+
+		<div id="content" class="site-content">
+
+<div id="primary" class="content-area">
+	<main id="main" class="site-main" role="main">
+
+<article id="post-5" class="post-5 page type-page status-publish hentry">
+	<header class="entry-header">
+		<h1 class="entry-title">[rails_template]</h1>	</header><!-- .entry-header -->
+
+
+	<div class="entry-content">
+		<p>[rails_content]</p>
+	</div><!-- .entry-content -->
+
+
+</article><!-- #post-## -->
+
+	</main><!-- .site-main -->
+
+
+</div><!-- .content-area -->
+
+
+
+		</div><!-- .site-content -->
+
+		<footer id="colophon" class="site-footer" role="contentinfo">
+
+
+			<div class="site-info">
+								<span class="site-title"><a href="http://localhost:8888/" rel="home">Madeline System WP</a></span>
+				<a href="https://wordpress.org/">Proudly powered by WordPress</a>
+			</div><!-- .site-info -->
+		</footer><!-- .site-footer -->
+	</div><!-- .site-inner -->
+</div><!-- .site -->
+
+<script type='text/javascript' src='http://localhost:8888/wp-content/themes/twentysixteen/js/skip-link-focus-fix.js?ver=20151112'></script>
+<script type='text/javascript'>
+/* <![CDATA[ */
+var screenReaderText = {"expand":"expand child menu","collapse":"collapse child menu"};
+/* ]]> */
+</script>
+<script type='text/javascript' src='http://localhost:8888/wp-content/themes/twentysixteen/js/functions.js?ver=20151204'></script>
+<script type='text/javascript' src='http://localhost:8888/wp-includes/js/wp-embed.min.js?ver=4.4.1'></script>
+</body>
+</html>


### PR DESCRIPTION
* Adds sample wordpress layout file for specs
* Refactors wordpress library logic to read from fixture in dev/test
* Namespaces wordpress-related routing logic
* Gives relative paths in environment configs for template fetch
* Factors wordpress update logic into `WordpressEmbeddable` concern
* Creates static pages controller for WP test page