### PR TITLE
4437 - shift subsequent project steps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ config/database.yml
 /public/uploads
 .DS_Store
 .idea
+*.scratch
 *.swp
 *.swo
 .ruby-version

--- a/app/controllers/admin/project_steps_controller.rb
+++ b/app/controllers/admin/project_steps_controller.rb
@@ -41,8 +41,24 @@ class Admin::ProjectStepsController < Admin::AdminController
     @step = ProjectStep.find(params[:id])
     authorize @step
 
+    @step.assign_attributes(project_step_params)
+    days_shifted = @step.pending_days_shifted # Detect potential schedule shift.
+    subsequent_count = @step.subsequent_step_ids.size
     valid = @step.update_with_translations(project_step_params, translations_params(@step.permitted_locales))
-    render_step_partial(valid ? :show : :form)
+    # Ignore schedule shift if not successfully saved, or no subsequent steps to update.
+    days_shifted = 0 unless valid && subsequent_count > 0
+    render partial: "/admin/project_steps/project_step", locals: {step: @step,
+      mode: valid ? :show : :edit, days_shifted: days_shifted, subsequent_count: subsequent_count}
+  end
+
+  # Updates scheduled date of all project steps following this
+  def shift_subsequent
+    @step = ProjectStep.find(params[:id])
+    num_days = params[:num_days].to_i
+    authorize @step
+    ids = @step.subsequent_step_ids(@step.scheduled_date - num_days.days)
+    unused, notice = batch_operation(ids){ |step| step.adjust_scheduled_date(num_days) }
+    display_timeline(@step.project_id, notice)
   end
 
   def duplicate
@@ -93,12 +109,14 @@ class Admin::ProjectStepsController < Admin::AdminController
 
   # Returns the two values in an array, the project id, and a 'notice' string needed to redisplay
   # the timeline.
+  # 'step_ids' may either be an array of integer or comma separated string
   def batch_operation(step_ids)
     success_count = 0
     failure_count = 0
     project_id = nil
     raise_error = true
-    step_ids.split(',').each do |step_id|
+    step_ids = step_ids.split(',') if step_ids.is_a?(String)
+    step_ids.each do |step_id|
       begin
         step = ProjectStep.find(step_id)
         authorize step

--- a/app/policies/project_step_policy.rb
+++ b/app/policies/project_step_policy.rb
@@ -14,6 +14,10 @@ class ProjectStepPolicy < ApplicationPolicy
     update?
   end
 
+  def shift_subsequent?
+    update?
+  end
+
   def finalize?
     update?
   end

--- a/app/views/admin/project_steps/_project_step.html.slim
+++ b/app/views/admin/project_steps/_project_step.html.slim
@@ -9,6 +9,15 @@ div.panel.step style="border-color: #{step.border_color}" data-step-id="#{step.i
 
   = render "admin/project_steps/duplicate_step_modal", step: step if policy(step).duplicate?
 
+  - days_shifted ||= 0
+  - if days_shifted > 0
+    = render "admin/project_steps/shift_subsequent_confirm_modal", step: step,
+      days_shifted: days_shifted, subsequent_count: subsequent_count
+    javascript:
+      $(function () {
+        $("#step-shift-subsequent-confirm-modal-#{step.id}").modal("show");
+      });
+
   javascript:
     $(document).ready(function() {
       new MS.Views.ProjectStepView({

--- a/app/views/admin/project_steps/_project_step.html.slim
+++ b/app/views/admin/project_steps/_project_step.html.slim
@@ -13,10 +13,6 @@ div.panel.step style="border-color: #{step.border_color}" data-step-id="#{step.i
   - if days_shifted > 0
     = render "admin/project_steps/shift_subsequent_confirm_modal", step: step,
       days_shifted: days_shifted, subsequent_count: subsequent_count
-    javascript:
-      $(function () {
-        $("#step-shift-subsequent-confirm-modal-#{step.id}").modal("show");
-      });
 
   javascript:
     $(document).ready(function() {

--- a/app/views/admin/project_steps/_shift_subsequent_confirm_modal.html.slim
+++ b/app/views/admin/project_steps/_shift_subsequent_confirm_modal.html.slim
@@ -18,3 +18,8 @@ div.modal.fade.duplicate-step [id="step-shift-subsequent-confirm-modal-#{step.id
 
         = link_to(t(:yes), shift_subsequent_admin_project_step_path(@step, num_days: days_shifted),
           method: :patch, class: "btn btn-primary")
+
+javascript:
+  $(function () {
+    $("#step-shift-subsequent-confirm-modal-#{step.id}").modal("show");
+  });

--- a/app/views/admin/project_steps/_shift_subsequent_confirm_modal.html.slim
+++ b/app/views/admin/project_steps/_shift_subsequent_confirm_modal.html.slim
@@ -1,0 +1,20 @@
+div.modal.fade.duplicate-step [id="step-shift-subsequent-confirm-modal-#{step.id}" tabindex="-1"
+  aria-labelledby="shift-subsequent-label"]
+
+  div.modal-dialog
+    div.modal-content
+      div.modal-header
+        button type="button" class="close" data-dismiss="modal"
+          span aria-hidden="true" &times;
+        h4.modal-title id="shift-subsequent-label"
+          = t("project_step.shift_subsequent")
+
+      div.modal-body
+        = t("project_step.confirm_shift_subsequent", count: subsequent_count, days: days_shifted)
+
+      div.modal-footer
+        button.btn.btn-default type="button" data-dismiss="modal"
+          = t(:no)
+
+        = link_to(t(:yes), shift_subsequent_admin_project_step_path(@step, num_days: days_shifted),
+          method: :patch, class: "btn btn-primary")

--- a/config/locales/en/en.yml
+++ b/config/locales/en/en.yml
@@ -172,6 +172,8 @@ en:
 
   project_step:
     after: "After"
+    confirm_deletion: "Are you sure you want to delete this project step?  NOTE, %{log_count} log(s) will also be deleted."
+    confirm_shift_subsequent: "Shift %{count} subsequent project step scheduled date(s) forward by %{days} days?"
     days: "Day(s)"
     delete_step: "Delete Step"
     duplicate: "Duplicate"
@@ -179,7 +181,6 @@ en:
     edit_step: "Edit Step"
     end: "End:"
     every: "Every:"
-    confirm_deletion: 'Are you sure you want to delete this project step?  NOTE, %{log_count} log(s) will also be deleted.'
     batch_delete_confirm: "Are you sure you want to delete these project steps?"
     batch_finalize_confirm: "Are you sure you wish to finalize these project steps?"
     finalized: "Finalized:"
@@ -200,6 +201,7 @@ en:
       one: "project step"
       other: "project steps"
     repeat: "Repeat..."
+    shift_subsequent: "Shift Subsequent Completion Dates"
     timeline: "Timeline"
     status:
       completed: "Completed"

--- a/config/locales/en/en.yml
+++ b/config/locales/en/en.yml
@@ -174,7 +174,9 @@ en:
   project_step:
     after: "After"
     confirm_deletion: "Are you sure you want to delete this project step?  NOTE, %{log_count} log(s) will also be deleted."
-    confirm_shift_subsequent: "Shift %{count} subsequent project step scheduled date(s) forward by %{days} days?"
+    confirm_shift_subsequent:
+      one: "We detected that you just moved the scheduled date of a finalized step back %{days} days. Would you also like to shift the subsequent step date back by %{days} days?"
+      other: "We detected that you just moved the scheduled date of a finalized step back %{days} days. Would you also like to shift the %{count} subsequent step dates back by %{days} days?"
     days: "Day(s)"
     delete_step: "Delete Step"
     duplicate: "Duplicate"
@@ -202,7 +204,7 @@ en:
       one: "project step"
       other: "project steps"
     repeat: "Repeat..."
-    shift_subsequent: "Shift Subsequent Completion Dates"
+    shift_subsequent: "Shift Subsequent Completion Dates?"
     timeline: "Timeline"
     status:
       completed: "Completed"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,6 +20,9 @@ Rails.application.routes.draw do
       member do
         post :duplicate
       end
+      member do
+        patch :shift_subsequent
+      end
     end
     resources :project_logs
 


### PR DESCRIPTION
modal confirmation and logic to shift out subsequent step schedule dates when prior step updated as late