### PR TITLE
4609: Empty date click opens new step on loan calendar only

### DIFF
--- a/app/assets/javascripts/backbone/views/calendar_view.js.coffee
+++ b/app/assets/javascripts/backbone/views/calendar_view.js.coffee
@@ -28,7 +28,7 @@ class MS.Views.CalendarView extends Backbone.View
     'click .loan-calendar .cal-step': 'showStepModal'
 
   dayClick: (date) ->
-    if @$el.find('.loan-calendar')
+    if @$el.find('.loan-calendar').length
       loanId = @$el.find('.loan-calendar').data('loan-id')
       new MS.Views.CalendarStepModalView(
         context: 'calendar',


### PR DESCRIPTION
Fixes loading indicator showing when global calendar's empty dates are clicked