### PR TITLE
4589 translatable fields

### DIFF
--- a/app/assets/javascripts/backbone/views/media_view.coffee
+++ b/app/assets/javascripts/backbone/views/media_view.coffee
@@ -49,6 +49,7 @@ class MS.Views.MediaView extends Backbone.View
     $.get @$(link).attr('href'), (html) =>
       @$('.media-modal .modal-content').html(html)
       @$('.media-modal').modal('show')
+      new MS.Views.TranslationsView(el: $('[data-content-translatable="media"]'));
       MS.loadingIndicator.hide()
 
   submitComplete: (e, data) ->

--- a/app/assets/javascripts/backbone/views/media_view.coffee
+++ b/app/assets/javascripts/backbone/views/media_view.coffee
@@ -49,7 +49,7 @@ class MS.Views.MediaView extends Backbone.View
     $.get @$(link).attr('href'), (html) =>
       @$('.media-modal .modal-content').html(html)
       @$('.media-modal').modal('show')
-      new MS.Views.TranslationsView(el: $('[data-content-translatable="media"]'));
+      new MS.Views.TranslationsView(el: @$('[data-content-translatable="media"]'));
       MS.loadingIndicator.hide()
 
   submitComplete: (e, data) ->

--- a/app/assets/stylesheets/admin/_language_block.scss
+++ b/app/assets/stylesheets/admin/_language_block.scss
@@ -5,9 +5,23 @@
   padding: 10px;
   border: 1px solid $gray4;
 
-  .form-control {
+  &:last-of-type {
     margin-bottom: 10px;
   }
+
+  .form-group:last-of-type {
+    margin-bottom: 0;
+  }
+
+  a.remove-language {
+    float: right;
+  }
+}
+
+// For some reason the usual .form-group bottom margin doesn't work on this form
+// Consider refactoring later.
+.project-step-form .language-block .form-control {
+  margin-bottom: 10px;
 }
 
 // Keep translatable language select box a natural width

--- a/app/assets/stylesheets/admin/_language_block.scss
+++ b/app/assets/stylesheets/admin/_language_block.scss
@@ -16,17 +16,15 @@
   a.remove-language {
     float: right;
   }
+
+  // Keep translatable language select box a natural width
+  select[id^=loan_locale_] {
+    width: auto;
+  }
 }
 
 // For some reason the usual .form-group bottom margin doesn't work on this form
 // Consider refactoring later.
 .project-step-form .language-block .form-control {
   margin-bottom: 10px;
-}
-
-// Keep translatable language select box a natural width
-.languages {
-  select {
-    width: auto;
-  }
 }

--- a/app/assets/stylesheets/admin/_language_block.scss
+++ b/app/assets/stylesheets/admin/_language_block.scss
@@ -9,3 +9,10 @@
     margin-bottom: 10px;
   }
 }
+
+// Keep translatable language select box a natural width
+.languages {
+  select {
+    width: auto;
+  }
+}

--- a/app/assets/stylesheets/admin/logs/_log_modal.scss
+++ b/app/assets/stylesheets/admin/logs/_log_modal.scss
@@ -25,7 +25,6 @@
     display: block;
     float: none;
     margin-left: 10em;
-    margin-bottom: 15px;
 
     .action {
       float: none;

--- a/app/controllers/admin/loans_controller.rb
+++ b/app/controllers/admin/loans_controller.rb
@@ -55,7 +55,7 @@ class Admin::LoansController < Admin::AdminController
   end
 
   def create
-    @loan = Loan.new(loan_params)
+    @loan = Loan.new(loan_attribs)
     authorize @loan
 
     if @loan.save
@@ -82,16 +82,15 @@ class Admin::LoansController < Admin::AdminController
 
   def loan_attribs
     params.require(:loan).permit(*(
-    [
-      :division_id, :organization_id, :loan_type_value, :status_value, :name,
-      :amount, :currency_id, :primary_agent_id, :secondary_agent_id,
-      :length_months, :rate, :signing_date, :first_payment_date, :first_interest_payment_date,
-      :target_end_date, :projected_return, :representative_id,
-      :project_type_value, :public_level_value
-    ] +
-      translation_params(:summary, :details)))
+      [
+        :division_id, :organization_id, :loan_type_value, :status_value, :name,
+        :amount, :currency_id, :primary_agent_id, :secondary_agent_id,
+        :length_months, :rate, :signing_date, :first_payment_date, :first_interest_payment_date,
+        :target_end_date, :projected_return, :representative_id,
+        :project_type_value, :public_level_value
+      ] + translation_params(:summary, :details)
+    ))
   end
-
 
   def prep_form_vars
     @division_choices = division_choices

--- a/app/controllers/admin/loans_controller.rb
+++ b/app/controllers/admin/loans_controller.rb
@@ -44,7 +44,7 @@ class Admin::LoansController < Admin::AdminController
   def update
     @loan = Loan.find(params[:id])
     authorize @loan
-    @loan.assign_attributes(loan_attribs)
+    @loan.assign_attributes(loan_params)
 
     if @loan.save
       redirect_to admin_loan_path(@loan), notice: I18n.t(:notice_updated)
@@ -55,7 +55,7 @@ class Admin::LoansController < Admin::AdminController
   end
 
   def create
-    @loan = Loan.new(loan_attribs)
+    @loan = Loan.new(loan_params)
     authorize @loan
 
     if @loan.save
@@ -80,7 +80,7 @@ class Admin::LoansController < Admin::AdminController
 
   private
 
-  def loan_attribs
+  def loan_params
     params.require(:loan).permit(*(
       [
         :division_id, :organization_id, :loan_type_value, :status_value, :name,

--- a/app/controllers/admin/loans_controller.rb
+++ b/app/controllers/admin/loans_controller.rb
@@ -1,4 +1,6 @@
 class Admin::LoansController < Admin::AdminController
+  include TranslationSaveable
+
   def index
     # Note, current_division is used when creating new entities and is guaranteed to return a value.
     # selected_division is used for index filtering, and may be unassigned.
@@ -42,8 +44,9 @@ class Admin::LoansController < Admin::AdminController
   def update
     @loan = Loan.find(params[:id])
     authorize @loan
+    @loan.assign_attributes(loan_attribs)
 
-    if @loan.update(loan_params)
+    if @loan.save
       redirect_to admin_loan_path(@loan), notice: I18n.t(:notice_updated)
     else
       prep_form_vars
@@ -77,15 +80,18 @@ class Admin::LoansController < Admin::AdminController
 
   private
 
-  def loan_params
-    params.require(:loan).permit(
+  def loan_attribs
+    params.require(:loan).permit(*(
+    [
       :division_id, :organization_id, :loan_type_value, :status_value, :name,
-      :amount, :currency_id, :summary, :primary_agent_id, :secondary_agent_id,
+      :amount, :currency_id, :primary_agent_id, :secondary_agent_id,
       :length_months, :rate, :signing_date, :first_payment_date, :first_interest_payment_date,
-      :target_end_date, :projected_return, :representative_id, :details,
+      :target_end_date, :projected_return, :representative_id,
       :project_type_value, :public_level_value
-    )
+    ] +
+      translation_params(:summary, :details)))
   end
+
 
   def prep_form_vars
     @division_choices = division_choices

--- a/app/controllers/admin/media_controller.rb
+++ b/app/controllers/admin/media_controller.rb
@@ -12,7 +12,7 @@ class Admin::MediaController < Admin::AdminController
   end
 
   def create
-    @media.assign_attributes(media_attribs)
+    @media.assign_attributes(media_params)
     if @media.save
       render partial: "admin/media/index", locals: {owner: @media.media_attachable}
     else
@@ -23,7 +23,7 @@ class Admin::MediaController < Admin::AdminController
 
   def destroy
     @media.destroy
-    
+
     if request.xhr?
       render partial: "admin/media/index", locals: {owner: @attachable}
     else
@@ -52,7 +52,7 @@ class Admin::MediaController < Admin::AdminController
     render partial: "admin/media/modal_content", status: status
   end
 
-  def media_attribs
+  def media_params
     params.require(:media).permit(*([:item] + translation_params(:caption, :description)))
   end
 end

--- a/app/controllers/admin/media_controller.rb
+++ b/app/controllers/admin/media_controller.rb
@@ -1,4 +1,6 @@
 class Admin::MediaController < Admin::AdminController
+  include TranslationSaveable
+
   before_action :find_attachable, :find_media, :authorize_media
 
   def new
@@ -10,8 +12,8 @@ class Admin::MediaController < Admin::AdminController
   end
 
   def create
-    @media.update_attributes(media_params)
-    if @media.valid?
+    @media.assign_attributes(media_attribs)
+    if @media.save
       render partial: "admin/media/index", locals: {owner: @media.media_attachable}
     else
       render_modal_partial(status: 422)
@@ -50,8 +52,7 @@ class Admin::MediaController < Admin::AdminController
     render partial: "admin/media/modal_content", status: status
   end
 
-  def media_params
-    # TODO: Generic method for whitelisting translatable params as part of Translatable module
-    params.require(:media).permit(:item, :caption_en, :caption_es, :caption_fr)
+  def media_attribs
+    params.require(:media).permit(*([:item] + translation_params(:caption, :description)))
   end
 end

--- a/app/controllers/admin/project_logs_controller.rb
+++ b/app/controllers/admin/project_logs_controller.rb
@@ -19,14 +19,14 @@ class Admin::ProjectLogsController < Admin::AdminController
   end
 
   def create
-    @log = ProjectLog.new(project_log_attribs)
+    @log = ProjectLog.new(project_log_params)
     authorize_with_parents
     save_and_render_partial
   end
 
   def update
     @log = ProjectLog.find(params[:id])
-    @log.assign_attributes(project_log_attribs)
+    @log.assign_attributes(project_log_params)
     authorize_with_parents
     save_and_render_partial
   end
@@ -55,7 +55,7 @@ class Admin::ProjectLogsController < Admin::AdminController
     authorize @loan
   end
 
-  def project_log_attribs
+  def project_log_params
     params.require(:project_log).permit(*(
       [:agent_id, :date, :project_step_id, :progress_metric_value] +
       translation_params(:summary, :details, :additional_notes, :private_notes)))

--- a/app/models/concerns/translatable.rb
+++ b/app/models/concerns/translatable.rb
@@ -96,13 +96,20 @@ module Translatable
   end
 
   def used_locales
-    translations.map(&:locale).uniq
+    translations.order(:locale).map{ |t| t.locale.to_sym }.uniq
   end
 
   # Returns all locales for which we have translations, or an array
   # containing only the current locale if there are no translations.
+  # Always includes current locale, orders additional locales by locale code
   def used_locales_or_current_locale
-    used_locales.presence || [I18n.locale]
+    locales = used_locales
+    if locales.include?(I18n.locale)
+      # Make sure default locale is displayed first if present
+      [I18n.locale] | locales
+    else
+      locales
+    end
   end
 
   def deleted_locales=(locales)

--- a/app/models/concerns/translatable.rb
+++ b/app/models/concerns/translatable.rb
@@ -108,7 +108,7 @@ module Translatable
       # Make sure default locale is displayed first if present
       [I18n.locale] | locales
     else
-      locales
+      locales.presence || [I18n.locale]
     end
   end
 

--- a/app/models/division.rb
+++ b/app/models/division.rb
@@ -25,7 +25,6 @@
 #
 
 class Division < ActiveRecord::Base
-  include CustomFieldAddable  # supports 'default_locales' persistence
   has_closure_tree dependent: :restrict_with_exception
   resourcify
   alias_attribute :super_division, :parent

--- a/app/views/admin/loans/content/_form.html.slim
+++ b/app/views/admin/loans/content/_form.html.slim
@@ -36,9 +36,7 @@
     .view-element = @loan.currency.try(:name)
     = f.input_field :currency_id, collection: @currency_choices, include_blank: true
 
-  = f.input :summary
-    .view-element = @loan.summary
-    = f.input_field :summary, as: :text
+  = render 'admin/loans/content/translatable', loan: @loan, f: f
 
   = authorized_form_field(simple_form: f, model: @loan, field_name: :primary_agent,
     choices: @agent_choices)
@@ -76,10 +74,6 @@
 
   = authorized_form_field(simple_form: f, model: @loan, field_name: :representative,
     choices: @representative_choices)
-
-  = f.input :details
-    .view-element = @loan.details
-    = f.input_field :details, as: :text
 
   = f.input :project_type
     .view-element = @loan.project_type_label

--- a/app/views/admin/loans/content/_translatable.slim
+++ b/app/views/admin/loans/content/_translatable.slim
@@ -1,9 +1,8 @@
 .view-element
-  = f.input :details
-    = @loan.details
-
   = f.input :summary
     = @loan.summary
+  = f.input :details
+    = @loan.details
 
 .form-element
   .languages data-content-translatable="loan"

--- a/app/views/admin/loans/content/_translatable.slim
+++ b/app/views/admin/loans/content/_translatable.slim
@@ -1,0 +1,28 @@
+.view-element
+  = f.input :details
+    = @loan.details
+
+  = f.input :summary
+    = @loan.summary
+
+.form-element
+  .languages data-content-translatable="loan"
+    input type='hidden' name='loan[deleted_locales][]'
+    - loan.used_locales_or_current_locale.each do |l|
+      .language-block data-locale="#{l}"
+        .clearfix
+          = f.input :"locale_#{l}", label: false,
+            collection: locale_options,
+            input_html: {class: 'locale'}, include_blank: false
+          = f.input :"summary_#{l}",
+            input_html: {data: {translatable: 'common.summary'}},
+            placeholder: I18n.t('common.summary', locale: l),
+            label: I18n.t('common.summary', locale: l)
+        = f.input :"details_#{l}", as: :text,
+          input_html: {rows: 3, data: {translatable: 'common.details'}},
+          placeholder: I18n.t('common.details', locale: l),
+          label: I18n.t('common.details', locale: l)
+
+        a.remove-language href='#' = t('common.remove')
+        .clearfix
+    a.add-language href='#' = t('common.add_language')

--- a/app/views/admin/loans/content/_translatable.slim
+++ b/app/views/admin/loans/content/_translatable.slim
@@ -23,3 +23,8 @@
             placeholder: I18n.t('common.details', locale: l),
             label: I18n.t('common.details', locale: l)
     a.add-language href='#' = t('common.add_language')
+
+javascript:
+  $(function() {
+    new MS.Views.TranslationsView({el: $('[data-content-translatable="loan"]')});
+  });

--- a/app/views/admin/loans/content/_translatable.slim
+++ b/app/views/admin/loans/content/_translatable.slim
@@ -9,7 +9,8 @@
     input type='hidden' name='loan[deleted_locales][]'
     - loan.used_locales_or_current_locale.each do |l|
       .language-block data-locale="#{l}"
-        .clearfix
+        a.remove-language href='#' = t('common.remove')
+        div.fields
           = f.input :"locale_#{l}", label: false,
             collection: locale_options,
             input_html: {class: 'locale'}, include_blank: false
@@ -17,11 +18,8 @@
             input_html: {data: {translatable: 'common.summary'}},
             placeholder: I18n.t('common.summary', locale: l),
             label: I18n.t('common.summary', locale: l)
-        = f.input :"details_#{l}", as: :text,
-          input_html: {rows: 3, data: {translatable: 'common.details'}},
-          placeholder: I18n.t('common.details', locale: l),
-          label: I18n.t('common.details', locale: l)
-
-        a.remove-language href='#' = t('common.remove')
-        .clearfix
+          = f.input :"details_#{l}", as: :text,
+            input_html: {rows: 3, data: {translatable: 'common.details'}},
+            placeholder: I18n.t('common.details', locale: l),
+            label: I18n.t('common.details', locale: l)
     a.add-language href='#' = t('common.add_language')

--- a/app/views/admin/loans/show.html.slim
+++ b/app/views/admin/loans/show.html.slim
@@ -36,4 +36,5 @@ javascript:
       el: '.nav-tabs',
       calendar_events_url: #{json @calendar_events_url}
     })
+    new MS.Views.TranslationsView({el: $('[data-content-translatable="loan"]')})
   })

--- a/app/views/admin/loans/show.html.slim
+++ b/app/views/admin/loans/show.html.slim
@@ -30,11 +30,11 @@ section.loan.details class=(@loan.valid? ? 'show-view' : 'edit-view')
 = render "admin/media/modal"
 
 javascript:
-  $(function(){
-    new MS.Views.ShowEditView({ el: '.loan.details' })
+  $(function() {
+    new MS.Views.ShowEditView({el: '.loan.details'});
     new MS.Views.LoanTabView({
       el: '.nav-tabs',
       calendar_events_url: #{json @calendar_events_url}
-    })
-    new MS.Views.TranslationsView({el: $('[data-content-translatable="loan"]')})
-  })
+    });
+    new MS.Views.TranslationsView({el: $('[data-content-translatable="loan"]')});
+  });

--- a/app/views/admin/loans/show.html.slim
+++ b/app/views/admin/loans/show.html.slim
@@ -36,5 +36,4 @@ javascript:
       el: '.nav-tabs',
       calendar_events_url: #{json @calendar_events_url}
     });
-    new MS.Views.TranslationsView({el: $('[data-content-translatable="loan"]')});
   });

--- a/app/views/admin/media/_modal_content.html.slim
+++ b/app/views/admin/media/_modal_content.html.slim
@@ -7,9 +7,7 @@ div.modal-body
   = simple_form_for [:admin, @media], url: @submit_url, remote: true do |f|
     = f.error_notification
     = f.input :item
-    - I18n.available_locales.each do |locale|
-      - locale_name = t("locale_name.#{locale}")
-      = f.input "caption_#{locale}".to_sym, label: t('media.caption', locale_name: locale_name)
+    = render 'admin/media/translatable', media: @media, f: f
 
 div.modal-footer
   button.btn.btn-default.media-action.cancel type="button" = t(:cancel)

--- a/app/views/admin/media/_translatable.html.slim
+++ b/app/views/admin/media/_translatable.html.slim
@@ -2,19 +2,13 @@
   input type='hidden' name='media[deleted_locales][]'
   - media.used_locales_or_current_locale.each do |l|
     .language-block data-locale="#{l}"
-      .clearfix
+      a.remove-language href='#' = t('common.remove')
+      div.fields
         = f.input :"locale_#{l}", label: false,
           collection: locale_options,
           input_html: {class: 'locale'}, include_blank: false
-      = f.input :"caption_#{l}",
-        input_html: {data: {translatable: 'common.summary'}},
-        placeholder: I18n.t('common.caption', locale: l),
-        label: I18n.t('common.caption', locale: l)
-      = f.input :"description_#{l}", as: :text,
-        input_html: {rows: 3, data: {translatable: 'common.details'}},
-        placeholder: I18n.t('common.description', locale: l),
-        label: I18n.t('common.description', locale: l)
-
-      a.remove-language href='#' = t('common.remove')
-      .clearfix
+        = f.input :"caption_#{l}",
+          input_html: {data: {translatable: 'common.summary'}},
+          placeholder: I18n.t('common.caption', locale: l),
+          label: I18n.t('common.caption', locale: l)
   a.add-language href='#' = t('common.add_language')

--- a/app/views/admin/media/_translatable.html.slim
+++ b/app/views/admin/media/_translatable.html.slim
@@ -1,0 +1,20 @@
+.languages data-content-translatable="media"
+  input type='hidden' name='media[deleted_locales][]'
+  - media.used_locales_or_current_locale.each do |l|
+    .language-block data-locale="#{l}"
+      .clearfix
+        = f.input :"locale_#{l}", label: false,
+          collection: locale_options,
+          input_html: {class: 'locale'}, include_blank: false
+      = f.input :"caption_#{l}",
+        input_html: {data: {translatable: 'common.summary'}},
+        placeholder: I18n.t('common.caption', locale: l),
+        label: I18n.t('common.caption', locale: l)
+      = f.input :"description_#{l}", as: :text,
+        input_html: {rows: 3, data: {translatable: 'common.details'}},
+        placeholder: I18n.t('common.description', locale: l),
+        label: I18n.t('common.description', locale: l)
+
+      a.remove-language href='#' = t('common.remove')
+      .clearfix
+  a.add-language href='#' = t('common.add_language')

--- a/app/views/admin/project_logs/_translatable.slim
+++ b/app/views/admin/project_logs/_translatable.slim
@@ -2,7 +2,8 @@
   input type='hidden' name='project_log[deleted_locales][]'
   - log.used_locales_or_current_locale.each do |l|
     .language-block data-locale="#{l}"
-      .clearfix
+      a.remove-language href='#' = t('common.remove')
+      div.fields
         = f.input :"locale_#{l}", label: false,
           collection: locale_options,
           input_html: {class: 'locale'}, include_blank: false
@@ -10,25 +11,21 @@
           input_html: {data: {translatable: 'common.summary'}},
           placeholder: I18n.t('common.summary', locale: l),
           label: I18n.t('common.summary', locale: l)
-      = f.input :"details_#{l}", as: :text,
-        input_html: {rows: 3, data: {translatable: 'common.details'}},
-        placeholder: I18n.t('common.details', locale: l),
-        label: I18n.t('common.details', locale: l)
-
-      div.expandable data-expandable='additional_notes'
+        = f.input :"details_#{l}", as: :text,
+          input_html: {rows: 3, data: {translatable: 'common.details'}},
+          placeholder: I18n.t('common.details', locale: l),
+          label: I18n.t('common.details', locale: l)
         = f.input :"additional_notes_#{l}", as: :text,
           input_html: {rows: 3, data: {translatable: 'log.additional_notes'}},
+          wrapper_html: {class: 'expandable', data: {expandable: 'additional_notes'}},
           placeholder: I18n.t('log.additional_notes', locale: l),
           label: I18n.t('log.additional_notes', locale: l)
-      div.expandable data-expandable='private_notes'
         = f.input :"private_notes_#{l}", as: :text,
           input_html: {rows: 3, data: {translatable: 'log.private_notes'}},
+          wrapper_html: {class: 'expandable', data: {expandable: 'private_notes'}},
           placeholder: I18n.t('log.private_notes', locale: l),
           label: I18n.t('log.private_notes', locale: l)
       div.actions
         a.action data-control='additional_notes' = t('log.additional_notes')
         a.action data-control='private_notes' = t('log.private_notes')
-
-      a.remove-language href='#' = t('common.remove')
-      .clearfix
   a.add-language href='#' = t('common.add_language')

--- a/app/views/admin/project_steps/_form.html.slim
+++ b/app/views/admin/project_steps/_form.html.slim
@@ -16,17 +16,16 @@ div.panel-body class=('new-record' if step.new_record?)
       input type="hidden" name="project_step[deleted_locales][]"
       - step.used_locales_or_current_locale.each do |l|
         .language-block data-locale="#{l}"
-          .clearfix
-            = f.input "locale_#{l}".to_sym, label: false,
-              collection: locale_options,
-              wrapper: :step_form_left_2, input_html: {class: 'locale'}, include_blank: false
-            = f.input "summary_#{l}".to_sym, wrapper: :step_form_left_12,
-              input_html: {data: {translatable: 'common.summary'}},
-              placeholder: I18n.t('common.summary', locale: l)
+          a.remove-language href="#" = t('common.remove')
+          = f.input "locale_#{l}".to_sym, label: false,
+            collection: locale_options,
+            wrapper: :step_form_left_2, input_html: {class: 'locale'}, include_blank: false
+          = f.input "summary_#{l}".to_sym, wrapper: :step_form_left_12,
+            input_html: {data: {translatable: 'common.summary'}},
+            placeholder: I18n.t('common.summary', locale: l)
           = f.input "details_#{l}".to_sym, as: :text, wrapper: :step_form_left_12,
             input_html: {rows: 3, data: {translatable: 'common.details'}},
             placeholder: I18n.t('common.details', locale: l)
-          a.remove-language href="#" = t('common.remove')
           .clearfix
       a.add-language href="#" = t('common.add_language')
 

--- a/config/locales/en/en.yml
+++ b/config/locales/en/en.yml
@@ -215,6 +215,7 @@ en:
   common:
     add_language: "Add Language"
     address_state: "State"
+    caption: "Caption"
     description: "Description"
     details: "Details"
     division: "Division"

--- a/config/locales/es/es.yml
+++ b/config/locales/es/es.yml
@@ -66,6 +66,8 @@ es:
   common:
     details: Detalles
     summary: Resumen
+    caption: Subtítulo
+    description: Descripción
 
   will_paginate:
     previous_label: "&#8592; Anterior"

--- a/config/locales/fr/fr.yml
+++ b/config/locales/fr/fr.yml
@@ -9,3 +9,5 @@ fr:
   common:
     summary: Résumé
     details: Détails
+    caption: Légende
+    description: La description

--- a/lib/legacy/static_data.rb
+++ b/lib/legacy/static_data.rb
@@ -114,16 +114,6 @@ module Legacy
       org_field_set = CustomFieldSet.find_or_create_by(division: Division.root, internal_name: 'Organization')
       org_field_set.custom_fields.destroy_all
       org_field_set.custom_fields.create!(internal_name: 'is_recovered', data_type: 'boolean')
-
-      # loan_field_set = CustomFieldSet.find_or_create_by(division: Division.root, internal_name: 'Loan')
-      # loan_field_set.custom_fields.destroy_all
-      # loan_field_set.custom_fields.create!(internal_name: 'old_loan_criteria_id', data_type: 'number')
-
-      division_field_set = CustomFieldSet.find_or_create_by(division: Division.root, internal_name: 'Division')
-      division_field_set.custom_fields.destroy_all
-      # list of strings representing 2 char locale codes to be presented by default within translatable UIs
-      division_field_set.custom_fields.create!(internal_name: 'default_locales', data_type: 'list')
-
     end
 
 
@@ -157,8 +147,6 @@ module Legacy
 
       org_field_set = CustomFieldSet.find_or_create_by(division: Division.root, internal_name: 'Organization')
       org_field_set.custom_fields.create!(internal_name: 'dynamic_translatable_test', data_type: 'translatable')
-
-      ::Division.root.update_default_locales([:en, :es])
     end
 
   end


### PR DESCRIPTION
Add translatable support for Loan summary and details.  
Change Media form to use standardized translatable interface.
Remove obsolete per division default_locales dynamic attribute.
