### PR TITLE
4518: Fix shift dates modal being opened during wrong actions

### DIFF
--- a/app/assets/javascripts/backbone/views/project_step_view.coffee
+++ b/app/assets/javascripts/backbone/views/project_step_view.coffee
@@ -10,7 +10,10 @@ class MS.Views.ProjectStepView extends Backbone.View
     @persisted = params.persisted
     @duplicate = params.duplicate
     @context = @$el.data('context')
+    @daysShifted = params.daysShifted
+    @stepId = params.stepId
     new MS.Views.TranslationsView(el: @$('[data-content-translatable="step"]'))
+    @showShiftDatesModal()
 
   events:
     'click a.edit-step-action': 'showForm'
@@ -92,3 +95,7 @@ class MS.Views.ProjectStepView extends Backbone.View
     $.post @$(e.target).attr('href'), {_method: 'DELETE'}
     @$(e.target).closest('.log').remove()
     false
+
+  showShiftDatesModal: (e) ->
+    if ((@daysShifted > 0))
+      $("#step-shift-subsequent-confirm-modal-#{@stepId}").modal("show")

--- a/app/views/admin/project_steps/_project_step.html.slim
+++ b/app/views/admin/project_steps/_project_step.html.slim
@@ -26,6 +26,8 @@ div.panel.step [
       new MS.Views.ProjectStepView({
         el: $('.step[data-step-id=#{step.id_or_temp_id}][data-context=#{context}]'),
         duplicate: #{json params[:action] == 'duplicate'},
-        persisted: #{json step.persisted?}
+        persisted: #{json step.persisted?},
+        daysShifted: #{days_shifted},
+        stepId: #{step.id}
       });
     });

--- a/app/views/admin/project_steps/_shift_subsequent_confirm_modal.html.slim
+++ b/app/views/admin/project_steps/_shift_subsequent_confirm_modal.html.slim
@@ -1,4 +1,4 @@
-div.modal.fade.duplicate-step [id="step-shift-subsequent-confirm-modal-#{step.id}" tabindex="-1"
+div.modal.fade.shift-step [id="step-shift-subsequent-confirm-modal-#{step.id}" tabindex="-1"
   aria-labelledby="shift-subsequent-label"]
 
   div.modal-dialog
@@ -18,8 +18,3 @@ div.modal.fade.duplicate-step [id="step-shift-subsequent-confirm-modal-#{step.id
 
         = link_to(t(:yes), shift_subsequent_admin_project_step_path(@step, num_days: days_shifted),
           method: :patch, class: "btn btn-primary")
-
-javascript:
-  $(function () {
-    $("#step-shift-subsequent-confirm-modal-#{step.id}").modal("show");
-  });


### PR DESCRIPTION
Fix shift dates modal displaying when delete and duplicate step modals are displayed

- Move JS for shift dates into step view model
- Change class that opened modal when wrong action called