### PR TITLE
4622: Add step type to ghost steps

### DIFF
--- a/app/models/calendar_event.rb
+++ b/app/models/calendar_event.rb
@@ -104,6 +104,7 @@ class CalendarEvent
     @num_of_logs = step.logs_count
     @model_type = 'ProjectStep'
     @model_id = step.id
+    @step_type = step.step_type_value
     self
   end
 


### PR DESCRIPTION
Fix a bug that did not show correct icon for a ghost step based on original project step's step type