### PR TITLE
4737 abandoned - division inheritance of loan criteria questions and loan type required flags

### DIFF
--- a/app/models/custom_field.rb
+++ b/app/models/custom_field.rb
@@ -2,17 +2,18 @@
 #
 # Table name: custom_fields
 #
-#  created_at           :datetime         not null
-#  custom_field_set_id  :integer
-#  data_type            :string
-#  has_embeddable_media :boolean          default(FALSE), not null
-#  id                   :integer          not null, primary key
-#  internal_name        :string
-#  migration_position   :integer
-#  parent_id            :integer
-#  position             :integer
-#  required             :boolean          default(FALSE), not null
-#  updated_at           :datetime         not null
+#  created_at            :datetime         not null
+#  custom_field_set_id   :integer
+#  data_type             :string
+#  has_embeddable_media  :boolean          default(FALSE), not null
+#  id                    :integer          not null, primary key
+#  internal_name         :string
+#  migration_position    :integer
+#  override_associations :boolean          default(FALSE), not null
+#  parent_id             :integer
+#  position              :integer
+#  required              :boolean          default(FALSE), not null
+#  updated_at            :datetime         not null
 #
 # Indexes
 #

--- a/app/models/custom_field_set.rb
+++ b/app/models/custom_field_set.rb
@@ -114,17 +114,14 @@ class CustomFieldSet < ActiveRecord::Base
       match = CustomFieldSet.find_by(internal_name: internal_name, division: parent_division)
       if match
         # Remove fields inherited from a parent division which are overridden at this division level.
-        overridden_ids = result.map(&:overridden_id).compact
-        inheritted_fields = match.custom_fields.reject! { |f| overridden_ids.include?(f.id) }
-        merged_fields += inheritted_fields
-        # Todo: Do we need a field type which represents a removed overridden field?
+        #overridden_ids = result.map(&:overridden_id).compact
+        #inheritted_fields = match.custom_fields.reject! { |f| overridden_ids.include?(f.id) }
+        #merged_fields += inheritted_fields
+        merged_fields += match.custom_fields
       end
       parent_division = parent_division.parent
     end
-    # Todo: Confirm how position field will be handled in relation to division hierarchy by the
-    # questions management admin UI.
     result.sort { |left, right| left.position <=> right.position }
-    #puts "resolve_merged_fields result: #{result.inspect} - merged_fields: #{result.merged_fields}"
     result
   end
 

--- a/app/models/loan_type_question.rb
+++ b/app/models/loan_type_question.rb
@@ -1,0 +1,47 @@
+# == Schema Information
+#
+# Table name: loan_type_questions
+#
+#  created_at   :datetime         not null
+#  division_id  :integer
+#  id           :integer          not null, primary key
+#  loan_type_id :integer
+#  question_id  :integer
+#  required     :boolean          default(FALSE), not null
+#  updated_at   :datetime         not null
+#
+# Indexes
+#
+#  index_loan_type_questions_on_division_id   (division_id)
+#  index_loan_type_questions_on_loan_type_id  (loan_type_id)
+#  index_loan_type_questions_on_question_id   (question_id)
+#
+# Foreign Keys
+#
+#  fk_rails_15b94dd4b0  (loan_type_id => options.id)
+#  fk_rails_501c24a2e4  (division_id => divisions.id)
+#  fk_rails_75e6d6743d  (question_id => custom_fields.id)
+#
+
+# Relation data between loan types ('Option's owned by the 'loan_type' OptionSet) and
+# questions ('CustomField's owned by 'loan_criteria' or 'loan_post_analysis' 'CustomFieldSet's).
+# Indicates which questions should be required or hidden per loan type and division/sub-division.
+
+class LoanTypeQuestion < ActiveRecord::Base
+
+  # Resolves all relation records for given leaf division and loan type, merging in records
+  # from parent divisions which are not overridden.
+  # Note, this list includes matches from all question sets (i.e. criteria and post_analysis).
+  def self.resolve(division, loan_type)
+    result = []
+    division.ancestors.reverse.each do |d|
+      items = where(division: d, loan_type: loan_type)
+      question_ids = items.map(&:question_id)
+      # Remove overridden parent division records
+      result.reject! { |item| question_ids.include?(item.question_id) }
+      result += items
+    end
+    result
+  end
+
+end

--- a/db/migrate/20160718202833_create_loan_type_questions.rb
+++ b/db/migrate/20160718202833_create_loan_type_questions.rb
@@ -1,0 +1,16 @@
+class CreateLoanTypeQuestions < ActiveRecord::Migration
+  def change
+    create_table :loan_type_questions do |t|
+      t.references :division, index: true, foreign_key: true
+      t.references :loan_type, references: :option, index: true
+      t.references :question, references: :custom_field, index: true
+      # Todo: Confirm if we want a 'status' field which which could represent other possible
+      # values like 'hidden', or a single purpose boolean field.
+#      t.string :status     # values: 'required', ?'hidden'
+      t.boolean :required, default: false, null: false
+      t.timestamps null: false
+    end
+    add_foreign_key :loan_type_questions, :options, column: :loan_type_id
+    add_foreign_key :loan_type_questions, :custom_fields, column: :question_id
+  end
+end

--- a/db/migrate/20160718225532_add_overridden_id_to_custom_fields.rb
+++ b/db/migrate/20160718225532_add_overridden_id_to_custom_fields.rb
@@ -1,0 +1,5 @@
+class AddOverriddenIdToCustomFields < ActiveRecord::Migration
+  def change
+    add_reference :custom_fields, :overridden, references: :custom_fields
+  end
+end

--- a/db/migrate/20160718225532_add_overridden_id_to_custom_fields.rb
+++ b/db/migrate/20160718225532_add_overridden_id_to_custom_fields.rb
@@ -1,5 +1,0 @@
-class AddOverriddenIdToCustomFields < ActiveRecord::Migration
-  def change
-    add_reference :custom_fields, :overridden, references: :custom_fields
-  end
-end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,86 +11,90 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160718225532) do
-
+ActiveRecord::Schema.define(version: 20160719165018) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
   create_table "countries", force: :cascade do |t|
-    t.datetime "created_at",                    null: false
+    t.datetime "created_at", null: false
     t.integer  "default_currency_id"
-    t.string   "iso_code",            limit: 2
+    t.string   "iso_code", limit: 2
     t.string   "name"
-    t.datetime "updated_at",                    null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "currencies", force: :cascade do |t|
     t.string   "code"
-    t.datetime "created_at",   null: false
+    t.datetime "created_at", null: false
     t.string   "name"
     t.string   "short_symbol"
     t.string   "symbol"
-    t.datetime "updated_at",   null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "custom_field_hierarchies", id: false, force: :cascade do |t|
-    t.integer "ancestor_id",   null: false
+    t.integer "ancestor_id", null: false
     t.integer "descendant_id", null: false
-    t.integer "generations",   null: false
+    t.integer "generations", null: false
   end
 
-  add_index "custom_field_hierarchies", ["ancestor_id", "descendant_id", "generations"], name: "custom_field_anc_desc_idx", unique: true, using: :btree
+  add_index "custom_field_hierarchies", %w(ancestor_id descendant_id generations), name: "custom_field_anc_desc_idx", unique: true, using: :btree
   add_index "custom_field_hierarchies", ["descendant_id"], name: "custom_field_desc_idx", using: :btree
 
+  create_table "custom_field_requirements", force: :cascade do |t|
+    t.integer "custom_field_id"
+    t.integer "option_id"
+  end
+
   create_table "custom_field_sets", force: :cascade do |t|
-    t.datetime "created_at",    null: false
+    t.datetime "created_at", null: false
     t.integer  "division_id"
     t.string   "internal_name"
-    t.datetime "updated_at",    null: false
+    t.datetime "updated_at", null: false
   end
 
   add_index "custom_field_sets", ["division_id"], name: "index_custom_field_sets_on_division_id", using: :btree
 
   create_table "custom_fields", force: :cascade do |t|
-    t.datetime "created_at",                           null: false
+    t.datetime "created_at", null: false
     t.integer  "custom_field_set_id"
     t.string   "data_type"
     t.boolean  "has_embeddable_media", default: false, null: false
     t.string   "internal_name"
     t.integer  "migration_position"
-    t.integer  "overridden_id"
+    t.boolean  "override_associations", default: false, null: false
     t.integer  "parent_id"
     t.integer  "position"
-    t.boolean  "required",             default: false, null: false
-    t.datetime "updated_at",                           null: false
+    t.boolean  "required", default: false, null: false
+    t.datetime "updated_at", null: false
   end
 
   add_index "custom_fields", ["custom_field_set_id"], name: "index_custom_fields_on_custom_field_set_id", using: :btree
 
   create_table "custom_value_sets", force: :cascade do |t|
-    t.datetime "created_at",                     null: false
+    t.datetime "created_at", null: false
     t.json     "custom_data"
-    t.integer  "custom_field_set_id",            null: false
-    t.integer  "custom_value_set_linkable_id",   null: false
+    t.integer  "custom_field_set_id", null: false
+    t.integer  "custom_value_set_linkable_id", null: false
     t.string   "custom_value_set_linkable_type", null: false
     t.string   "linkable_attribute"
-    t.datetime "updated_at",                     null: false
+    t.datetime "updated_at", null: false
   end
 
   add_index "custom_value_sets", ["custom_field_set_id"], name: "index_custom_value_sets_on_custom_field_set_id", using: :btree
   add_index "custom_value_sets", ["custom_value_set_linkable_type", "custom_value_set_linkable_id"], name: "custom_value_sets_on_linkable", using: :btree
 
   create_table "division_hierarchies", id: false, force: :cascade do |t|
-    t.integer "ancestor_id",   null: false
+    t.integer "ancestor_id", null: false
     t.integer "descendant_id", null: false
-    t.integer "generations",   null: false
+    t.integer "generations", null: false
   end
 
-  add_index "division_hierarchies", ["ancestor_id", "descendant_id", "generations"], name: "division_anc_desc_idx", unique: true, using: :btree
+  add_index "division_hierarchies", %w(ancestor_id descendant_id generations), name: "division_anc_desc_idx", unique: true, using: :btree
   add_index "division_hierarchies", ["descendant_id"], name: "division_desc_idx", using: :btree
 
   create_table "divisions", force: :cascade do |t|
-    t.datetime "created_at",      null: false
+    t.datetime "created_at", null: false
     t.integer  "currency_id"
     t.json     "custom_data"
     t.text     "description"
@@ -98,38 +102,25 @@ ActiveRecord::Schema.define(version: 20160718225532) do
     t.string   "name"
     t.integer  "organization_id"
     t.integer  "parent_id"
-    t.datetime "updated_at",      null: false
+    t.datetime "updated_at", null: false
   end
 
   add_index "divisions", ["currency_id"], name: "index_divisions_on_currency_id", using: :btree
   add_index "divisions", ["organization_id"], name: "index_divisions_on_organization_id", using: :btree
 
   create_table "embeddable_media", force: :cascade do |t|
-    t.datetime "created_at",   null: false
+    t.datetime "created_at", null: false
     t.integer  "height"
     t.text     "html"
     t.string   "original_url"
-    t.datetime "updated_at",   null: false
+    t.datetime "updated_at", null: false
     t.string   "url"
     t.integer  "width"
   end
 
-  create_table "loan_type_questions", force: :cascade do |t|
-    t.datetime "created_at",                   null: false
-    t.integer  "division_id"
-    t.integer  "loan_type_id"
-    t.integer  "question_id"
-    t.boolean  "required",     default: false, null: false
-    t.datetime "updated_at",                   null: false
-  end
-
-  add_index "loan_type_questions", ["division_id"], name: "index_loan_type_questions_on_division_id", using: :btree
-  add_index "loan_type_questions", ["loan_type_id"], name: "index_loan_type_questions_on_loan_type_id", using: :btree
-  add_index "loan_type_questions", ["question_id"], name: "index_loan_type_questions_on_question_id", using: :btree
-
   create_table "loans", force: :cascade do |t|
     t.decimal  "amount"
-    t.datetime "created_at",                  null: false
+    t.datetime "created_at", null: false
     t.integer  "currency_id"
     t.json     "custom_data"
     t.integer  "division_id"
@@ -150,7 +141,7 @@ ActiveRecord::Schema.define(version: 20160718225532) do
     t.date     "signing_date"
     t.string   "status_value"
     t.date     "target_end_date"
-    t.datetime "updated_at",                  null: false
+    t.datetime "updated_at", null: false
   end
 
   add_index "loans", ["currency_id"], name: "index_loans_on_currency_id", using: :btree
@@ -159,7 +150,7 @@ ActiveRecord::Schema.define(version: 20160718225532) do
   add_index "loans", ["organization_snapshot_id"], name: "index_loans_on_organization_snapshot_id", using: :btree
 
   create_table "media", force: :cascade do |t|
-    t.datetime "created_at",            null: false
+    t.datetime "created_at", null: false
     t.string   "item"
     t.string   "item_content_type"
     t.integer  "item_file_size"
@@ -169,7 +160,7 @@ ActiveRecord::Schema.define(version: 20160718225532) do
     t.integer  "media_attachable_id"
     t.string   "media_attachable_type"
     t.integer  "sort_order"
-    t.datetime "updated_at",            null: false
+    t.datetime "updated_at", null: false
     t.integer  "uploader_id"
   end
 
@@ -177,31 +168,31 @@ ActiveRecord::Schema.define(version: 20160718225532) do
 
   create_table "notes", force: :cascade do |t|
     t.integer  "author_id"
-    t.datetime "created_at",   null: false
+    t.datetime "created_at", null: false
     t.integer  "notable_id"
     t.string   "notable_type"
-    t.datetime "updated_at",   null: false
+    t.datetime "updated_at", null: false
   end
 
   add_index "notes", ["author_id"], name: "index_notes_on_author_id", using: :btree
   add_index "notes", ["notable_type", "notable_id"], name: "index_notes_on_notable_type_and_notable_id", using: :btree
 
   create_table "option_sets", force: :cascade do |t|
-    t.datetime "created_at",      null: false
-    t.integer  "division_id",     null: false
+    t.datetime "created_at", null: false
+    t.integer  "division_id", null: false
     t.string   "model_attribute"
     t.string   "model_type"
-    t.datetime "updated_at",      null: false
+    t.datetime "updated_at", null: false
   end
 
   add_index "option_sets", ["division_id"], name: "index_option_sets_on_division_id", using: :btree
 
   create_table "options", force: :cascade do |t|
-    t.datetime "created_at",    null: false
+    t.datetime "created_at", null: false
     t.integer  "migration_id"
     t.integer  "option_set_id"
     t.integer  "position"
-    t.datetime "updated_at",    null: false
+    t.datetime "updated_at", null: false
     t.string   "value"
   end
 
@@ -225,7 +216,7 @@ ActiveRecord::Schema.define(version: 20160718225532) do
     t.string   "city"
     t.text     "contact_notes"
     t.integer  "country_id"
-    t.datetime "created_at",               null: false
+    t.datetime "created_at", null: false
     t.json     "custom_data"
     t.integer  "division_id"
     t.string   "email"
@@ -245,7 +236,7 @@ ActiveRecord::Schema.define(version: 20160718225532) do
     t.string   "state"
     t.text     "street_address"
     t.string   "tax_no"
-    t.datetime "updated_at",               null: false
+    t.datetime "updated_at", null: false
     t.string   "website"
   end
 
@@ -256,12 +247,12 @@ ActiveRecord::Schema.define(version: 20160718225532) do
     t.string   "city"
     t.text     "contact_notes"
     t.integer  "country_id"
-    t.datetime "created_at",                              null: false
+    t.datetime "created_at", null: false
     t.integer  "division_id"
     t.string   "email"
     t.string   "fax"
     t.string   "first_name"
-    t.boolean  "has_system_access",       default: false, null: false
+    t.boolean  "has_system_access", default: false, null: false
     t.string   "last_name"
     t.string   "legal_name"
     t.string   "name"
@@ -273,7 +264,7 @@ ActiveRecord::Schema.define(version: 20160718225532) do
     t.string   "state"
     t.text     "street_address"
     t.string   "tax_no"
-    t.datetime "updated_at",                              null: false
+    t.datetime "updated_at", null: false
     t.string   "website"
   end
 
@@ -281,12 +272,12 @@ ActiveRecord::Schema.define(version: 20160718225532) do
 
   create_table "project_logs", force: :cascade do |t|
     t.integer  "agent_id"
-    t.datetime "created_at",            null: false
+    t.datetime "created_at", null: false
     t.date     "date"
     t.date     "date_changed_to"
     t.string   "progress_metric_value"
     t.integer  "project_step_id"
-    t.datetime "updated_at",            null: false
+    t.datetime "updated_at", null: false
   end
 
   add_index "project_logs", ["agent_id"], name: "index_project_logs_on_agent_id", using: :btree
@@ -295,7 +286,7 @@ ActiveRecord::Schema.define(version: 20160718225532) do
   create_table "project_steps", force: :cascade do |t|
     t.integer  "agent_id"
     t.date     "completed_date"
-    t.datetime "created_at",                    null: false
+    t.datetime "created_at", null: false
     t.integer  "date_change_count", default: 0, null: false
     t.datetime "finalized_at"
     t.boolean  "is_finalized"
@@ -304,7 +295,7 @@ ActiveRecord::Schema.define(version: 20160718225532) do
     t.string   "project_type"
     t.date     "scheduled_date"
     t.string   "step_type_value"
-    t.datetime "updated_at",                    null: false
+    t.datetime "updated_at", null: false
   end
 
   add_index "project_steps", ["agent_id"], name: "index_project_steps_on_agent_id", using: :btree
@@ -312,13 +303,13 @@ ActiveRecord::Schema.define(version: 20160718225532) do
 
   create_table "roles", force: :cascade do |t|
     t.datetime "created_at"
-    t.string   "name",          null: false
+    t.string   "name", null: false
     t.integer  "resource_id"
     t.string   "resource_type"
     t.datetime "updated_at"
   end
 
-  add_index "roles", ["name", "resource_type", "resource_id"], name: "index_roles_on_name_and_resource_type_and_resource_id", unique: true, using: :btree
+  add_index "roles", %w(name resource_type resource_id), name: "index_roles_on_name_and_resource_type_and_resource_id", unique: true, using: :btree
   add_index "roles", ["name"], name: "index_roles_on_name", using: :btree
 
   create_table "translations", force: :cascade do |t|
@@ -334,19 +325,19 @@ ActiveRecord::Schema.define(version: 20160718225532) do
   add_index "translations", ["translatable_type", "translatable_id"], name: "index_translations_on_translatable_type_and_translatable_id", using: :btree
 
   create_table "users", force: :cascade do |t|
-    t.datetime "created_at",                          null: false
+    t.datetime "created_at", null: false
     t.datetime "current_sign_in_at"
     t.inet     "current_sign_in_ip"
-    t.string   "email",                  default: "", null: false
-    t.string   "encrypted_password",     default: "", null: false
+    t.string   "email", default: "", null: false
+    t.string   "encrypted_password", default: "", null: false
     t.datetime "last_sign_in_at"
     t.inet     "last_sign_in_ip"
     t.integer  "profile_id"
     t.datetime "remember_created_at"
     t.datetime "reset_password_sent_at"
     t.string   "reset_password_token"
-    t.integer  "sign_in_count",          default: 0,  null: false
-    t.datetime "updated_at",                          null: false
+    t.integer  "sign_in_count", default: 0, null: false
+    t.datetime "updated_at", null: false
   end
 
   add_index "users", ["email"], name: "index_users_on_email", unique: true, using: :btree
@@ -366,9 +357,6 @@ ActiveRecord::Schema.define(version: 20160718225532) do
   add_foreign_key "custom_value_sets", "custom_field_sets"
   add_foreign_key "divisions", "currencies"
   add_foreign_key "divisions", "organizations"
-  add_foreign_key "loan_type_questions", "custom_fields", column: "question_id"
-  add_foreign_key "loan_type_questions", "divisions"
-  add_foreign_key "loan_type_questions", "options", column: "loan_type_id"
   add_foreign_key "loans", "currencies"
   add_foreign_key "loans", "divisions"
   add_foreign_key "loans", "organizations"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -12,46 +12,47 @@
 # It's strongly recommended that you check this file into your version control system.
 
 ActiveRecord::Schema.define(version: 20160718225532) do
+
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
   create_table "countries", force: :cascade do |t|
-    t.datetime "created_at", null: false
+    t.datetime "created_at",                    null: false
     t.integer  "default_currency_id"
-    t.string   "iso_code", limit: 2
+    t.string   "iso_code",            limit: 2
     t.string   "name"
-    t.datetime "updated_at", null: false
+    t.datetime "updated_at",                    null: false
   end
 
   create_table "currencies", force: :cascade do |t|
     t.string   "code"
-    t.datetime "created_at", null: false
+    t.datetime "created_at",   null: false
     t.string   "name"
     t.string   "short_symbol"
     t.string   "symbol"
-    t.datetime "updated_at", null: false
+    t.datetime "updated_at",   null: false
   end
 
   create_table "custom_field_hierarchies", id: false, force: :cascade do |t|
-    t.integer "ancestor_id", null: false
+    t.integer "ancestor_id",   null: false
     t.integer "descendant_id", null: false
-    t.integer "generations", null: false
+    t.integer "generations",   null: false
   end
 
-  add_index "custom_field_hierarchies", %w(ancestor_id descendant_id generations), name: "custom_field_anc_desc_idx", unique: true, using: :btree
+  add_index "custom_field_hierarchies", ["ancestor_id", "descendant_id", "generations"], name: "custom_field_anc_desc_idx", unique: true, using: :btree
   add_index "custom_field_hierarchies", ["descendant_id"], name: "custom_field_desc_idx", using: :btree
 
   create_table "custom_field_sets", force: :cascade do |t|
-    t.datetime "created_at", null: false
+    t.datetime "created_at",    null: false
     t.integer  "division_id"
     t.string   "internal_name"
-    t.datetime "updated_at", null: false
+    t.datetime "updated_at",    null: false
   end
 
   add_index "custom_field_sets", ["division_id"], name: "index_custom_field_sets_on_division_id", using: :btree
 
   create_table "custom_fields", force: :cascade do |t|
-    t.datetime "created_at", null: false
+    t.datetime "created_at",                           null: false
     t.integer  "custom_field_set_id"
     t.string   "data_type"
     t.boolean  "has_embeddable_media", default: false, null: false
@@ -60,36 +61,36 @@ ActiveRecord::Schema.define(version: 20160718225532) do
     t.integer  "overridden_id"
     t.integer  "parent_id"
     t.integer  "position"
-    t.boolean  "required", default: false, null: false
-    t.datetime "updated_at", null: false
+    t.boolean  "required",             default: false, null: false
+    t.datetime "updated_at",                           null: false
   end
 
   add_index "custom_fields", ["custom_field_set_id"], name: "index_custom_fields_on_custom_field_set_id", using: :btree
 
   create_table "custom_value_sets", force: :cascade do |t|
-    t.datetime "created_at", null: false
+    t.datetime "created_at",                     null: false
     t.json     "custom_data"
-    t.integer  "custom_field_set_id", null: false
-    t.integer  "custom_value_set_linkable_id", null: false
+    t.integer  "custom_field_set_id",            null: false
+    t.integer  "custom_value_set_linkable_id",   null: false
     t.string   "custom_value_set_linkable_type", null: false
     t.string   "linkable_attribute"
-    t.datetime "updated_at", null: false
+    t.datetime "updated_at",                     null: false
   end
 
   add_index "custom_value_sets", ["custom_field_set_id"], name: "index_custom_value_sets_on_custom_field_set_id", using: :btree
   add_index "custom_value_sets", ["custom_value_set_linkable_type", "custom_value_set_linkable_id"], name: "custom_value_sets_on_linkable", using: :btree
 
   create_table "division_hierarchies", id: false, force: :cascade do |t|
-    t.integer "ancestor_id", null: false
+    t.integer "ancestor_id",   null: false
     t.integer "descendant_id", null: false
-    t.integer "generations", null: false
+    t.integer "generations",   null: false
   end
 
-  add_index "division_hierarchies", %w(ancestor_id descendant_id generations), name: "division_anc_desc_idx", unique: true, using: :btree
+  add_index "division_hierarchies", ["ancestor_id", "descendant_id", "generations"], name: "division_anc_desc_idx", unique: true, using: :btree
   add_index "division_hierarchies", ["descendant_id"], name: "division_desc_idx", using: :btree
 
   create_table "divisions", force: :cascade do |t|
-    t.datetime "created_at", null: false
+    t.datetime "created_at",      null: false
     t.integer  "currency_id"
     t.json     "custom_data"
     t.text     "description"
@@ -97,29 +98,29 @@ ActiveRecord::Schema.define(version: 20160718225532) do
     t.string   "name"
     t.integer  "organization_id"
     t.integer  "parent_id"
-    t.datetime "updated_at", null: false
+    t.datetime "updated_at",      null: false
   end
 
   add_index "divisions", ["currency_id"], name: "index_divisions_on_currency_id", using: :btree
   add_index "divisions", ["organization_id"], name: "index_divisions_on_organization_id", using: :btree
 
   create_table "embeddable_media", force: :cascade do |t|
-    t.datetime "created_at", null: false
+    t.datetime "created_at",   null: false
     t.integer  "height"
     t.text     "html"
     t.string   "original_url"
-    t.datetime "updated_at", null: false
+    t.datetime "updated_at",   null: false
     t.string   "url"
     t.integer  "width"
   end
 
   create_table "loan_type_questions", force: :cascade do |t|
-    t.datetime "created_at", null: false
+    t.datetime "created_at",                   null: false
     t.integer  "division_id"
     t.integer  "loan_type_id"
     t.integer  "question_id"
-    t.boolean  "required", default: false, null: false
-    t.datetime "updated_at", null: false
+    t.boolean  "required",     default: false, null: false
+    t.datetime "updated_at",                   null: false
   end
 
   add_index "loan_type_questions", ["division_id"], name: "index_loan_type_questions_on_division_id", using: :btree
@@ -128,7 +129,7 @@ ActiveRecord::Schema.define(version: 20160718225532) do
 
   create_table "loans", force: :cascade do |t|
     t.decimal  "amount"
-    t.datetime "created_at", null: false
+    t.datetime "created_at",                  null: false
     t.integer  "currency_id"
     t.json     "custom_data"
     t.integer  "division_id"
@@ -149,7 +150,7 @@ ActiveRecord::Schema.define(version: 20160718225532) do
     t.date     "signing_date"
     t.string   "status_value"
     t.date     "target_end_date"
-    t.datetime "updated_at", null: false
+    t.datetime "updated_at",                  null: false
   end
 
   add_index "loans", ["currency_id"], name: "index_loans_on_currency_id", using: :btree
@@ -158,7 +159,7 @@ ActiveRecord::Schema.define(version: 20160718225532) do
   add_index "loans", ["organization_snapshot_id"], name: "index_loans_on_organization_snapshot_id", using: :btree
 
   create_table "media", force: :cascade do |t|
-    t.datetime "created_at", null: false
+    t.datetime "created_at",            null: false
     t.string   "item"
     t.string   "item_content_type"
     t.integer  "item_file_size"
@@ -168,7 +169,7 @@ ActiveRecord::Schema.define(version: 20160718225532) do
     t.integer  "media_attachable_id"
     t.string   "media_attachable_type"
     t.integer  "sort_order"
-    t.datetime "updated_at", null: false
+    t.datetime "updated_at",            null: false
     t.integer  "uploader_id"
   end
 
@@ -176,31 +177,31 @@ ActiveRecord::Schema.define(version: 20160718225532) do
 
   create_table "notes", force: :cascade do |t|
     t.integer  "author_id"
-    t.datetime "created_at", null: false
+    t.datetime "created_at",   null: false
     t.integer  "notable_id"
     t.string   "notable_type"
-    t.datetime "updated_at", null: false
+    t.datetime "updated_at",   null: false
   end
 
   add_index "notes", ["author_id"], name: "index_notes_on_author_id", using: :btree
   add_index "notes", ["notable_type", "notable_id"], name: "index_notes_on_notable_type_and_notable_id", using: :btree
 
   create_table "option_sets", force: :cascade do |t|
-    t.datetime "created_at", null: false
-    t.integer  "division_id", null: false
+    t.datetime "created_at",      null: false
+    t.integer  "division_id",     null: false
     t.string   "model_attribute"
     t.string   "model_type"
-    t.datetime "updated_at", null: false
+    t.datetime "updated_at",      null: false
   end
 
   add_index "option_sets", ["division_id"], name: "index_option_sets_on_division_id", using: :btree
 
   create_table "options", force: :cascade do |t|
-    t.datetime "created_at", null: false
+    t.datetime "created_at",    null: false
     t.integer  "migration_id"
     t.integer  "option_set_id"
     t.integer  "position"
-    t.datetime "updated_at", null: false
+    t.datetime "updated_at",    null: false
     t.string   "value"
   end
 
@@ -224,7 +225,7 @@ ActiveRecord::Schema.define(version: 20160718225532) do
     t.string   "city"
     t.text     "contact_notes"
     t.integer  "country_id"
-    t.datetime "created_at", null: false
+    t.datetime "created_at",               null: false
     t.json     "custom_data"
     t.integer  "division_id"
     t.string   "email"
@@ -244,7 +245,7 @@ ActiveRecord::Schema.define(version: 20160718225532) do
     t.string   "state"
     t.text     "street_address"
     t.string   "tax_no"
-    t.datetime "updated_at", null: false
+    t.datetime "updated_at",               null: false
     t.string   "website"
   end
 
@@ -255,12 +256,12 @@ ActiveRecord::Schema.define(version: 20160718225532) do
     t.string   "city"
     t.text     "contact_notes"
     t.integer  "country_id"
-    t.datetime "created_at", null: false
+    t.datetime "created_at",                              null: false
     t.integer  "division_id"
     t.string   "email"
     t.string   "fax"
     t.string   "first_name"
-    t.boolean  "has_system_access", default: false, null: false
+    t.boolean  "has_system_access",       default: false, null: false
     t.string   "last_name"
     t.string   "legal_name"
     t.string   "name"
@@ -272,7 +273,7 @@ ActiveRecord::Schema.define(version: 20160718225532) do
     t.string   "state"
     t.text     "street_address"
     t.string   "tax_no"
-    t.datetime "updated_at", null: false
+    t.datetime "updated_at",                              null: false
     t.string   "website"
   end
 
@@ -280,12 +281,12 @@ ActiveRecord::Schema.define(version: 20160718225532) do
 
   create_table "project_logs", force: :cascade do |t|
     t.integer  "agent_id"
-    t.datetime "created_at", null: false
+    t.datetime "created_at",            null: false
     t.date     "date"
     t.date     "date_changed_to"
     t.string   "progress_metric_value"
     t.integer  "project_step_id"
-    t.datetime "updated_at", null: false
+    t.datetime "updated_at",            null: false
   end
 
   add_index "project_logs", ["agent_id"], name: "index_project_logs_on_agent_id", using: :btree
@@ -294,7 +295,7 @@ ActiveRecord::Schema.define(version: 20160718225532) do
   create_table "project_steps", force: :cascade do |t|
     t.integer  "agent_id"
     t.date     "completed_date"
-    t.datetime "created_at", null: false
+    t.datetime "created_at",                    null: false
     t.integer  "date_change_count", default: 0, null: false
     t.datetime "finalized_at"
     t.boolean  "is_finalized"
@@ -303,7 +304,7 @@ ActiveRecord::Schema.define(version: 20160718225532) do
     t.string   "project_type"
     t.date     "scheduled_date"
     t.string   "step_type_value"
-    t.datetime "updated_at", null: false
+    t.datetime "updated_at",                    null: false
   end
 
   add_index "project_steps", ["agent_id"], name: "index_project_steps_on_agent_id", using: :btree
@@ -311,13 +312,13 @@ ActiveRecord::Schema.define(version: 20160718225532) do
 
   create_table "roles", force: :cascade do |t|
     t.datetime "created_at"
-    t.string   "name", null: false
+    t.string   "name",          null: false
     t.integer  "resource_id"
     t.string   "resource_type"
     t.datetime "updated_at"
   end
 
-  add_index "roles", %w(name resource_type resource_id), name: "index_roles_on_name_and_resource_type_and_resource_id", unique: true, using: :btree
+  add_index "roles", ["name", "resource_type", "resource_id"], name: "index_roles_on_name_and_resource_type_and_resource_id", unique: true, using: :btree
   add_index "roles", ["name"], name: "index_roles_on_name", using: :btree
 
   create_table "translations", force: :cascade do |t|
@@ -333,19 +334,19 @@ ActiveRecord::Schema.define(version: 20160718225532) do
   add_index "translations", ["translatable_type", "translatable_id"], name: "index_translations_on_translatable_type_and_translatable_id", using: :btree
 
   create_table "users", force: :cascade do |t|
-    t.datetime "created_at", null: false
+    t.datetime "created_at",                          null: false
     t.datetime "current_sign_in_at"
     t.inet     "current_sign_in_ip"
-    t.string   "email", default: "", null: false
-    t.string   "encrypted_password", default: "", null: false
+    t.string   "email",                  default: "", null: false
+    t.string   "encrypted_password",     default: "", null: false
     t.datetime "last_sign_in_at"
     t.inet     "last_sign_in_ip"
     t.integer  "profile_id"
     t.datetime "remember_created_at"
     t.datetime "reset_password_sent_at"
     t.string   "reset_password_token"
-    t.integer  "sign_in_count", default: 0, null: false
-    t.datetime "updated_at", null: false
+    t.integer  "sign_in_count",          default: 0,  null: false
+    t.datetime "updated_at",                          null: false
   end
 
   add_index "users", ["email"], name: "index_users_on_email", unique: true, using: :btree

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160702193806) do
+ActiveRecord::Schema.define(version: 20160718225532) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -57,6 +57,7 @@ ActiveRecord::Schema.define(version: 20160702193806) do
     t.boolean  "has_embeddable_media", default: false, null: false
     t.string   "internal_name"
     t.integer  "migration_position"
+    t.integer  "overridden_id"
     t.integer  "parent_id"
     t.integer  "position"
     t.boolean  "required", default: false, null: false
@@ -111,6 +112,19 @@ ActiveRecord::Schema.define(version: 20160702193806) do
     t.string   "url"
     t.integer  "width"
   end
+
+  create_table "loan_type_questions", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.integer  "division_id"
+    t.integer  "loan_type_id"
+    t.integer  "question_id"
+    t.boolean  "required", default: false, null: false
+    t.datetime "updated_at", null: false
+  end
+
+  add_index "loan_type_questions", ["division_id"], name: "index_loan_type_questions_on_division_id", using: :btree
+  add_index "loan_type_questions", ["loan_type_id"], name: "index_loan_type_questions_on_loan_type_id", using: :btree
+  add_index "loan_type_questions", ["question_id"], name: "index_loan_type_questions_on_question_id", using: :btree
 
   create_table "loans", force: :cascade do |t|
     t.decimal  "amount"
@@ -351,6 +365,9 @@ ActiveRecord::Schema.define(version: 20160702193806) do
   add_foreign_key "custom_value_sets", "custom_field_sets"
   add_foreign_key "divisions", "currencies"
   add_foreign_key "divisions", "organizations"
+  add_foreign_key "loan_type_questions", "custom_fields", column: "question_id"
+  add_foreign_key "loan_type_questions", "divisions"
+  add_foreign_key "loan_type_questions", "options", column: "loan_type_id"
   add_foreign_key "loans", "currencies"
   add_foreign_key "loans", "divisions"
   add_foreign_key "loans", "organizations"


### PR DESCRIPTION
This was an incorrect implementation of 4737.  It provides logic for supporting inheritance of loan criteria questions from parent divisions and merging questions only added for child divisions.  It also supports being able to override the loan type / question required flags by subdivisions.  Neither is a feature needed for the initial release, but this code may be a useful reference in the future.