### PR TITLE
Explicitly give location of color variables

### DIFF
--- a/app/assets/stylesheets/admin/_general.scss
+++ b/app/assets/stylesheets/admin/_general.scss
@@ -1,6 +1,8 @@
 // General, miscellaneous styles to be used throughout the admin area.
 // General styles forming a cohesive, non-trivially sized group should be moved into separate file.
 
+@import "colors";
+
 body {
   font-family: 'Open Sans', sans-serif;
 }

--- a/app/assets/stylesheets/embedded/_scaffolds.scss
+++ b/app/assets/stylesheets/embedded/_scaffolds.scss
@@ -1,3 +1,5 @@
+@import "../admin/colors";
+
 /*body {
   background-color: #fff;
   color: #333;


### PR DESCRIPTION
- Is a work-around for a Sass inside Rails bug

Developer see the colors working properly unless branches are
changed or server is restarted. When that happens, the color
variables cannot be found without explicitly stating location.