### PR TITLE
5111: Adjust size of columns

### DIFF
--- a/app/assets/stylesheets/admin/loans/_tables.scss
+++ b/app/assets/stylesheets/admin/loans/_tables.scss
@@ -6,6 +6,7 @@
   margin-top: 1em;
   background: $white;
   word-wrap: break-word;
+  min-width: 60rem;
 
   thead {
     tr {
@@ -38,6 +39,6 @@
   }
 
   .wide {
-    width: 25%;
+    width: 20%;
   }
 }

--- a/app/views/admin/loans/content/_breakeven_table_question.html.slim
+++ b/app/views/admin/loans/content/_breakeven_table_question.html.slim
@@ -12,9 +12,9 @@
           th = t("loan.breakeven.product_name")
           th.wide = t("loan.breakeven.description")
           th = t("loan.breakeven.unit")
-          th.narrow = t("loan.breakeven.price")
-          th.narrow = t("loan.breakeven.cost")
-          th.narrow = t("loan.breakeven.quantity")
+          th = t("loan.breakeven.price")
+          th = t("loan.breakeven.cost")
+          th = t("loan.breakeven.quantity")
           th.narrow: .actions: a data-action="add": i.fa.fa-plus-circle
       tbody
         / Hidden row is used to generate new rows
@@ -34,7 +34,7 @@
       thead
         tr
           th = t("loan.breakeven.fixed_cost_name")
-          th.narrow = t("loan.breakeven.cost")
+          th = t("loan.breakeven.cost")
           th.narrow: .actions: a data-action="add": i.fa.fa-plus-circle
       tbody
         / Hidden row is used to generate new rows


### PR DESCRIPTION
Make columns wider in breakeven data tables.

Set minimum width so table does not scrunch
on small screens.