### PR TITLE
5425: Ensure log alert when no summary is present shows

### DIFF
--- a/app/views/admin/project_logs/_form.html.slim
+++ b/app/views/admin/project_logs/_form.html.slim
@@ -3,7 +3,8 @@
 
     = f.hidden_field(:project_step_id)
 
-    .alert.alert-danger.hidden.empty-log-error role="alert"
+    // The hide/show for this alert is in LogModalView. Do not use .hidden here.
+    .alert.alert-danger.empty-log-error role="alert"
       i.fa.fa-exclamation-circle>
       = t("log.empty_log_error")
 


### PR DESCRIPTION
Alert should show when there is no summary and user tries to save.