### PR TITLE
4785: Condense content inside date picker

### DIFF
--- a/app/assets/stylesheets/admin/_date_picker.scss
+++ b/app/assets/stylesheets/admin/_date_picker.scss
@@ -1,0 +1,13 @@
+.datepicker {
+  table {
+    tr {
+      td, th {
+        width: 20px;
+        height: 20px;
+        padding: 2px;
+        margin: 0;
+        line-height: 1;
+      }
+    }
+  }
+}

--- a/app/assets/stylesheets/admin/admin.scss
+++ b/app/assets/stylesheets/admin/admin.scss
@@ -7,6 +7,7 @@
 @import "jqtree";
 @import "layout";
 @import "calendar/*";
+@import "date_picker";
 @import "divisions";
 @import "forms/*";
 @import "general";


### PR DESCRIPTION
Fixes date picker being cut off underneath topmost header